### PR TITLE
DE-2377 - Backport to Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,19 +38,15 @@ plugins {
 group = "io.aiven"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 
     withJavadocJar()
     withSourcesJar()
 }
 
 compileJava {
-    options.compilerArgs = ["-Xlint:all", "-Werror"]
-}
-
-javadoc {
-    options.addBooleanOption('html5', true)
+    options.compilerArgs = ["-Xlint:all"]
 }
 
 wrapper {

--- a/src/main/java/io/aiven/kafka/connect/common/config/AivenCommonConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/common/config/AivenCommonConfig.java
@@ -86,7 +86,7 @@ public class AivenCommonConfig extends AbstractConfig {
                             return;
                         }
                         assert value instanceof Long;
-                        final var longValue = (Long) value;
+                        final Long longValue = (Long) value;
                         if (longValue < 0) {
                             throw new ConfigException(name, value, "Value must be at least 0");
                         } else if (longValue > MAXIMUM_BACKOFF_POLICY) {

--- a/src/main/java/io/aiven/kafka/connect/common/config/FilenameTemplateVariable.java
+++ b/src/main/java/io/aiven/kafka/connect/common/config/FilenameTemplateVariable.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.connect.common.config;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -28,7 +29,7 @@ public enum FilenameTemplateVariable {
         new ParameterDescriptor(
                 "padding",
                 false,
-                List.of(Boolean.TRUE.toString(), Boolean.FALSE.toString())
+                Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString())
         )
     ),
     START_OFFSET(
@@ -36,7 +37,7 @@ public enum FilenameTemplateVariable {
         new ParameterDescriptor(
             "padding",
             false,
-            List.of(Boolean.TRUE.toString(), Boolean.FALSE.toString())
+            Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString())
         )
     ),
     TIMESTAMP(
@@ -44,7 +45,7 @@ public enum FilenameTemplateVariable {
         new ParameterDescriptor(
             "unit",
             true,
-            List.of("yyyy", "MM", "dd", "HH")
+            Arrays.asList("yyyy", "MM", "dd", "HH")
         )
     );
 

--- a/src/main/java/io/aiven/kafka/connect/common/config/validators/FilenameTemplateValidator.java
+++ b/src/main/java/io/aiven/kafka/connect/common/config/validators/FilenameTemplateValidator.java
@@ -41,7 +41,7 @@ import static io.aiven.kafka.connect.common.grouper.RecordGrouperFactory.SUPPORT
 
 public final class FilenameTemplateValidator implements ConfigDef.Validator {
 
-    static final Map<String, ParameterDescriptor> SUPPORTED_VARIABLE_PARAMETERS = new LinkedHashMap<>() {{
+    static final Map<String, ParameterDescriptor> SUPPORTED_VARIABLE_PARAMETERS = new LinkedHashMap() {{
             put(PARTITION.name, PARTITION.parameterDescriptor);
             put(START_OFFSET.name, START_OFFSET.parameterDescriptor);
             put(TIMESTAMP.name, TIMESTAMP.parameterDescriptor);

--- a/src/main/java/io/aiven/kafka/connect/common/config/validators/NonEmptyPassword.java
+++ b/src/main/java/io/aiven/kafka/connect/common/config/validators/NonEmptyPassword.java
@@ -29,8 +29,8 @@ public class NonEmptyPassword implements ConfigDef.Validator {
         if (Objects.isNull(value)) {
             return;
         }
-        final var pwd = (Password) value;
-        if (pwd.value() == null || pwd.value().isBlank()) {
+        final Password pwd = (Password) value;
+        if (pwd == null || pwd.value().matches("\\s*")) {
             throw new ConfigException(name, pwd, "Password must be non-empty");
         }
 

--- a/src/main/java/io/aiven/kafka/connect/common/config/validators/UrlValidator.java
+++ b/src/main/java/io/aiven/kafka/connect/common/config/validators/UrlValidator.java
@@ -28,9 +28,9 @@ public class UrlValidator implements ConfigDef.Validator {
     @Override
     public void ensureValid(final String name, final Object value) {
         if (Objects.nonNull(value)) {
-            var valueStr = (String) value;
+            String valueStr = (String) value;
 
-            if (valueStr.isBlank()) {
+            if (valueStr.matches("\\s*")) {
                 throw new ConfigException(name, value, "String must be non-empty");
             }
 

--- a/src/main/java/io/aiven/kafka/connect/common/grouper/ParquetTopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/common/grouper/ParquetTopicPartitionRecordGrouper.java
@@ -62,12 +62,12 @@ class ParquetTopicPartitionRecordGrouper extends TopicPartitionRecordGrouper {
             if (Objects.isNull(record.valueSchema()) || Objects.isNull(record.keySchema())) {
                 throw new SchemaProjectorException("Record must have schemas for key and value");
             }
-            final var tp = new TopicPartition(record.topic(), record.kafkaPartition());
-            final var keyValueVersion =
+            final TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
+            final KeyValueSchema keyValueVersion =
                     keyValueSchemas.computeIfAbsent(tp, ignored -> new KeyValueSchema(
                             record.keySchema(),
                             record.valueSchema()));
-            final var schemaChanged =
+            final boolean schemaChanged =
                     !keyValueVersion.keySchema.equals(record.keySchema())
                             || !keyValueVersion.valueSchema.equals(record.valueSchema());
             if (schemaChanged) {
@@ -97,7 +97,7 @@ class ParquetTopicPartitionRecordGrouper extends TopicPartitionRecordGrouper {
                 if (o == null || getClass() != o.getClass()) {
                     return false;
                 }
-                final var that = (KeyValueSchema) o;
+                final KeyValueSchema that = (KeyValueSchema) o;
                 return keySchema.equals(that.keySchema) && valueSchema.equals(that.valueSchema);
             }
 

--- a/src/main/java/io/aiven/kafka/connect/common/grouper/RecordGrouperFactory.java
+++ b/src/main/java/io/aiven/kafka/connect/common/grouper/RecordGrouperFactory.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.connect.common.grouper;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -37,14 +38,15 @@ public final class RecordGrouperFactory {
 
     public static final String TOPIC_PARTITION_RECORD = TopicPartitionRecordGrouper.class.getName();
 
-    public static final Map<String, List<Pair<String, Boolean>>> SUPPORTED_VARIABLES = new LinkedHashMap<>() {{
-            put(TOPIC_PARTITION_RECORD, List.of(
+    public static final Map<String, List<Pair<String, Boolean>>> SUPPORTED_VARIABLES = new LinkedHashMap() {{
+            put(TOPIC_PARTITION_RECORD, Arrays.asList(
                 Pair.of(FilenameTemplateVariable.TOPIC.name, true),
                 Pair.of(FilenameTemplateVariable.PARTITION.name, true),
                 Pair.of(FilenameTemplateVariable.START_OFFSET.name, true),
-                Pair.of(FilenameTemplateVariable.TIMESTAMP.name, false)
-            ));
-            put(KEY_RECORD, List.of(Pair.of(FilenameTemplateVariable.KEY.name, true)));
+                Pair.of(FilenameTemplateVariable.TIMESTAMP.name, false))
+            );
+            put(KEY_RECORD, 
+                Arrays.asList(Pair.of(FilenameTemplateVariable.KEY.name, true)));
         }};
 
     public static final List<String> ALL_SUPPORTED_VARIABLES =

--- a/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
@@ -66,22 +66,23 @@ class TopicPartitionRecordGrouper implements RecordGrouper {
         Objects.requireNonNull(filenameTemplate, "filenameTemplate cannot be null");
         Objects.requireNonNull(tsSource, "tsSource cannot be null");
         this.filenameTemplate = filenameTemplate;
-        this.setTimestampBasedOnRecord = record -> new Function<>() {
+        this.setTimestampBasedOnRecord = record -> new Function() {
             private final Map<String, DateTimeFormatter> timestampFormatters =
-                Map.of(
-                    "yyyy", DateTimeFormatter.ofPattern("yyyy"),
-                    "MM", DateTimeFormatter.ofPattern("MM"),
-                    "dd", DateTimeFormatter.ofPattern("dd"),
-                    "HH", DateTimeFormatter.ofPattern("HH")
-                );
+                new HashMap<String, DateTimeFormatter>() {{
+                        put("yyyy", DateTimeFormatter.ofPattern("yyyy"));
+                        put("MM", DateTimeFormatter.ofPattern("MM"));
+                        put("dd", DateTimeFormatter.ofPattern("dd"));
+                        put("HH", DateTimeFormatter.ofPattern("HH"));
+                    }};
 
             @Override
-            public String apply(final Parameter parameter) {
+            public String apply(final Object p) {
+                final Parameter parameter = (Parameter) p;
                 return tsSource.time(record).format(timestampFormatters.get(parameter.value()));
             }
         };
         this.rotator = buffer -> {
-            final var unlimited = maxRecordsPerFile == null;
+            final boolean unlimited = maxRecordsPerFile == null;
             if (unlimited) {
                 return false;
             } else {

--- a/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
@@ -72,7 +72,7 @@ public abstract class OutputWriter implements AutoCloseable {
         if (sinkRecords.isEmpty()) {
             return;
         }
-        for (final var r : sinkRecords) {
+        for (final SinkRecord r : sinkRecords) {
             writeRecord(r);
         }
     }

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/HeaderBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/HeaderBuilder.java
@@ -17,7 +17,7 @@
 package io.aiven.kafka.connect.common.output.jsonwriter;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
 
 import org.apache.kafka.connect.header.Header;
@@ -39,7 +39,11 @@ class HeaderBuilder implements OutputFieldBuilder {
     public HeaderBuilder() {
         converter = new JsonConverter();
         // TODO: make a more generic configuration
-        converter.configure(Map.of("schemas.enable", false, "converter.type", "header"));
+        converter.configure(new HashMap<String, Object>() {{
+                put("schemas.enable", false);
+                put("converter.type", "header");
+            }}
+        );
     }
 
     @Override

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/KeyBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/KeyBuilder.java
@@ -17,7 +17,7 @@
 package io.aiven.kafka.connect.common.output.jsonwriter;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
 
 import org.apache.kafka.connect.errors.DataException;
@@ -36,7 +36,12 @@ class KeyBuilder implements OutputFieldBuilder {
     public KeyBuilder() {
         converter = new JsonConverter();
         // TODO: make a more generic configuration
-        converter.configure(Map.of("schemas.enable", false, "converter.type", "key"));
+        converter.configure(new HashMap<String, Object>() {{
+                put("schemas.enable", false);
+                put("converter.type", "key");
+            }}
+        );
+
     }
 
     /**

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/ValueBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/ValueBuilder.java
@@ -17,7 +17,7 @@
 package io.aiven.kafka.connect.common.output.jsonwriter;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
 
 import org.apache.kafka.connect.errors.DataException;
@@ -36,7 +36,12 @@ class ValueBuilder implements OutputFieldBuilder {
     public ValueBuilder() {
         converter = new JsonConverter();
         // TODO: make a more generic configuration
-        converter.configure(Map.of("schemas.enable", false, "converter.type", "value"));
+        converter.configure(new HashMap<String, Object>() {{
+                put("schemas.enable", false);
+                put("converter.type", "value");
+            }}
+        );
+        
     }
 
     /**

--- a/src/main/java/io/aiven/kafka/connect/common/output/parquet/ParquetConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/parquet/ParquetConfig.java
@@ -17,6 +17,7 @@
 package io.aiven.kafka.connect.common.output.parquet;
 
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -34,8 +35,8 @@ class ParquetConfig extends AbstractConfig {
     }
 
     public Configuration parquetConfiguration() {
-        final var config = new Configuration();
-        for (final var e : originalsWithPrefix("connect.").entrySet()) {
+        final Configuration config = new Configuration();
+        for (final Entry<String, Object> e : originalsWithPrefix("connect.").entrySet()) {
             if (!e.getKey().startsWith("parquet")) {
                 continue;
             }
@@ -50,7 +51,7 @@ class ParquetConfig extends AbstractConfig {
     }
 
     public CompressionCodecName compressionCodecName() {
-        final var connectorCompressionType =
+        final CompressionType connectorCompressionType =
                 CompressionType.forName(
                         originals().getOrDefault(
                                 AivenCommonConfig.FILE_COMPRESSION_TYPE_CONFIG,

--- a/src/test/java/io/aiven/kafka/connect/common/config/AivenCommonConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/config/AivenCommonConfigTest.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.connect.common.config;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigDef;
@@ -30,10 +31,10 @@ class AivenCommonConfigTest {
 
     @Test
     void invalidEnvelopeConfiguration() {
-        final Map<String, String> properties = Map.of(
-            "format.output.fields", "key,value",
-            "format.output.envelope", "false"
-        );
+        final Map<String, String> properties = new HashMap<String, String>() {{
+                put("format.output.fields", "key,value");
+                put("format.output.envelope", "false");
+            }};
 
         final ConfigDef definition = new ConfigDef();
         addOutputFieldsFormatConfigGroup(definition, OutputFieldType.VALUE);

--- a/src/test/java/io/aiven/kafka/connect/common/grouper/ParquetTopicPartitionRecordGrouperTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/grouper/ParquetTopicPartitionRecordGrouperTest.java
@@ -149,7 +149,7 @@ final class ParquetTopicPartitionRecordGrouperTest {
         grouper.put(KRT1P1R2);
         grouper.put(KRT1P1R3);
 
-        final var records = grouper.records();
+        final Map<String, List<SinkRecord>> records = grouper.records();
         assertThat(records)
             .containsOnly(
                 entry("topic1-0-1000", list(KRT1P1R0, KRT1P1R1)),

--- a/src/test/java/io/aiven/kafka/connect/common/output/JsonLinesOutputWriterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/JsonLinesOutputWriterTest.java
@@ -65,7 +65,7 @@ class JsonLinesOutputWriterTest extends JsonOutputWriterTestHelper {
 
     @Test
     void jsonValueWithValue() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding));
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding));
 
         sut = new JsonLinesOutputWriter(fields, byteStream);
 
@@ -226,7 +226,7 @@ class JsonLinesOutputWriterTest extends JsonOutputWriterTestHelper {
     // Still, it is not recommended to use it that way, because it could change.
     @Test
     void doNotHaveToFailIfLastRecordIsMissing() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding));
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding));
         sut = new JsonLinesOutputWriter(fields, byteStream);
 
         final Struct struct1 = new Struct(level1Schema).put("name", "John");

--- a/src/test/java/io/aiven/kafka/connect/common/output/JsonOutputWriterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/JsonOutputWriterTest.java
@@ -18,6 +18,7 @@ package io.aiven.kafka.connect.common.output;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -61,7 +62,7 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
 
     @Test
     void jsonValueWithValue() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding));
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding));
         sut = new JsonOutputWriter(fields, byteStream);
         final Struct struct1 = new Struct(level1Schema).put("name", "John");
 
@@ -90,7 +91,7 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
 
     @Test
     void jsonValueWithOneFieldAndValue() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding),
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
             new OutputField(OutputFieldType.KEY, noEncoding));
         sut = new JsonOutputWriter(fields, byteStream);
         final Struct struct1 = new Struct(level1Schema).put("name", "John");
@@ -104,7 +105,7 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
 
     @Test
     void multiStringJsonValueWithOneFieldAndValue() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding),
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
             new OutputField(OutputFieldType.KEY, noEncoding));
         sut = new JsonOutputWriter(fields, byteStream);
         final Struct struct1 = new Struct(level1Schema).put("name", "John");
@@ -116,12 +117,12 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
         final String expected = "[{\"value\":{\"name\":\"John\"},\"key\":\"key0\"},"
             + "{\"value\":{\"name\":\"Pekka\"},\"key\":\"key0\"}]";
 
-        assertRecords(List.of(record1, record2), expected);
+        assertRecords(Arrays.asList(record1, record2), expected);
     }
 
     @Test
     void jsonValueWithAllMetadata() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding),
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
             new OutputField(OutputFieldType.KEY, noEncoding),
             new OutputField(OutputFieldType.OFFSET, noEncoding),
             new OutputField(OutputFieldType.TIMESTAMP, noEncoding),
@@ -143,7 +144,7 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
 
     @Test
     void jsonValueWithMultipleHeaders() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding),
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
             new OutputField(OutputFieldType.HEADERS, noEncoding));
         sut = new JsonOutputWriter(fields, byteStream);
         final Struct struct1 = new Struct(level1Schema).put("name", "John");
@@ -174,7 +175,7 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
 
     @Test
     void jsonValueWithMissingKey() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding),
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
             new OutputField(OutputFieldType.KEY, noEncoding));
         sut = new JsonOutputWriter(fields, byteStream);
         final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
@@ -189,7 +190,7 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
 
     @Test
     void jsonValueWithMissingTimestamp() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding),
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
             new OutputField(OutputFieldType.TIMESTAMP, noEncoding));
         sut = new JsonOutputWriter(fields, byteStream);
         final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
@@ -204,7 +205,7 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
 
     @Test
     void jsonValueWithMissingHeader() throws IOException {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding),
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
             new OutputField(OutputFieldType.HEADERS, noEncoding));
         sut = new JsonOutputWriter(fields, byteStream);
         final Struct struct1 = new Struct(level1Schema).put("name", "John");
@@ -218,7 +219,7 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
 
     @Test
     void failedIfLastRecordIsMissing() {
-        final List<OutputField> fields = List.of(new OutputField(OutputFieldType.VALUE, noEncoding));
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding));
         sut = new JsonOutputWriter(fields, byteStream);
 
         final Struct struct1 = new Struct(level1Schema).put("name", "John");
@@ -227,7 +228,7 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
         final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
         final SinkRecord record2 = createRecord("key0", level1Schema, struct2, 1, 1000L);
 
-        assertThatThrownBy(() -> useWithWrongLastRecord(List.of(record1, record2)))
+        assertThatThrownBy(() -> useWithWrongLastRecord(Arrays.asList(record1, record2)))
             .isInstanceOf(JsonParseException.class);
     }
 

--- a/src/test/java/io/aiven/kafka/connect/common/output/parquet/ParquetConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/parquet/ParquetConfigTest.java
@@ -17,11 +17,13 @@
 package io.aiven.kafka.connect.common.output.parquet;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import io.aiven.kafka.connect.common.config.AivenCommonConfig;
 import io.aiven.kafka.connect.common.config.CompressionType;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.junit.jupiter.api.Test;
 
@@ -32,15 +34,15 @@ class ParquetConfigTest {
     @Test
     void testGenerateParquetConfig() {
 
-        final var origins = Map.of(
-                "connect.parquet.aa", "aa",
-                "connect.parquet.bb", "bb",
-                "connect.parquet.cc", "cc",
-                "connect.parquet.avro.schema", "aa"
-        );
+        final Map<String, String> origins = new HashMap<String, String>() {{
+                put("connect.parquet.aa", "aa");
+                put("connect.parquet.bb", "bb");
+                put("connect.parquet.cc", "cc");
+                put("connect.parquet.avro.schema", "aa");
+            }};
 
-        final var parquetConfig = new ParquetConfig(origins);
-        final var config = parquetConfig.parquetConfiguration();
+        final ParquetConfig parquetConfig = new ParquetConfig(origins);
+        final Configuration config = parquetConfig.parquetConfiguration();
 
         assertThat(config.get("parquet.aa")).isEqualTo("aa");
         assertThat(config.get("parquet.bb")).isEqualTo("bb");
@@ -52,14 +54,18 @@ class ParquetConfigTest {
     void testConvertCompressionTypeToParquetCompressorName() {
         assertThat(
                 new ParquetConfig(
-                        Map.of(AivenCommonConfig.FILE_COMPRESSION_TYPE_CONFIG, CompressionType.NONE.name)
+                    new HashMap<String, String>() {{
+                        put(AivenCommonConfig.FILE_COMPRESSION_TYPE_CONFIG, CompressionType.NONE.name);
+                    }}
                 ).compressionCodecName())
             .isEqualTo(CompressionCodecName.UNCOMPRESSED);
         assertThat(new ParquetConfig(Collections.emptyMap()).compressionCodecName())
             .isEqualTo(CompressionCodecName.UNCOMPRESSED);
         assertThat(
                 new ParquetConfig(
-                        Map.of(AivenCommonConfig.FILE_COMPRESSION_TYPE_CONFIG, CompressionType.ZSTD.name)
+                    new HashMap<String, String>() {{
+                        put(AivenCommonConfig.FILE_COMPRESSION_TYPE_CONFIG, CompressionType.ZSTD.name);
+                    }}
                 ).compressionCodecName())
             .isEqualTo(CompressionCodecName.ZSTD);
     }

--- a/src/test/java/io/aiven/kafka/connect/common/output/parquet/SinkRecordConverterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/parquet/SinkRecordConverterTest.java
@@ -16,9 +16,9 @@
 
 package io.aiven.kafka.connect.common.output.parquet;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
@@ -54,20 +54,20 @@ class SinkRecordConverterTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testConvertRecordWithOneFieldSimpleType(final boolean envelopeEnabled) {
-        final var fields =
-                List.of(new OutputField(OutputFieldType.OFFSET, OutputFieldEncodingType.NONE));
+        final List<OutputField> fields =
+                Arrays.asList(new OutputField(OutputFieldType.OFFSET, OutputFieldEncodingType.NONE));
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData, envelopeEnabled);
-        final var converter = new SinkRecordConverter(fields, avroData, envelopeEnabled);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData, envelopeEnabled);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData, envelopeEnabled);
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
                         Schema.STRING_SCHEMA, "some-value",
                         100L, 1000L, TimestampType.CREATE_TIME);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord.get(OutputFieldType.OFFSET.name)).isNotNull();
         assertThat(avroRecord.get(OutputFieldType.KEY.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.TIMESTAMP.name)).isNull();
@@ -80,20 +80,20 @@ class SinkRecordConverterTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testConvertRecordValueSimpleType(final boolean envelopeEnabled) {
-        final var fields =
-                List.of(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
+        final List<OutputField> fields =
+                Arrays.asList(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData, envelopeEnabled);
-        final var converter = new SinkRecordConverter(fields, avroData, envelopeEnabled);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData, envelopeEnabled);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData, envelopeEnabled);
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
                         Schema.STRING_SCHEMA, "some-value",
                         100L, 1000L, TimestampType.CREATE_TIME);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord.get(OutputFieldType.OFFSET.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.KEY.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.TIMESTAMP.name)).isNull();
@@ -103,19 +103,19 @@ class SinkRecordConverterTest {
 
     @Test
     void testConvertRecordValueStructType() {
-        final var fields =
-                List.of(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
+        final List<OutputField> fields =
+                Arrays.asList(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
-        final var converter = new SinkRecordConverter(fields, avroData);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData);
 
-        final var recordSchema =
+        final Schema recordSchema =
                 SchemaBuilder.struct()
                         .field("foo", Schema.STRING_SCHEMA)
                         .field("bar", SchemaBuilder.STRING_SCHEMA)
                         .build();
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
@@ -125,33 +125,33 @@ class SinkRecordConverterTest {
                                 .put("bar", "foo"),
                         100L, 1000L, TimestampType.CREATE_TIME);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord.get(OutputFieldType.OFFSET.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.KEY.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.TIMESTAMP.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.HEADERS.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.VALUE.name)).isNotNull();
 
-        final var valueRecord = (GenericRecord) avroRecord.get("value");
+        final GenericRecord valueRecord = (GenericRecord) avroRecord.get("value");
         assertThat(valueRecord.get("foo")).hasToString("bar");
         assertThat(valueRecord.get("bar")).hasToString("foo");
     }
 
     @Test
     void testConvertRecordValueStruct() {
-        final var fields =
-                List.of(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
+        final List<OutputField> fields =
+                Arrays.asList(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
-        final var converter = new SinkRecordConverter(fields, avroData);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData);
 
-        final var recordSchema = SchemaBuilder.struct()
+        final Schema recordSchema = SchemaBuilder.struct()
                 .field("user_name", Schema.STRING_SCHEMA)
                 .field("user_ip", Schema.STRING_SCHEMA)
                 .field("blocked", Schema.BOOLEAN_SCHEMA)
                 .build();
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
@@ -161,7 +161,7 @@ class SinkRecordConverterTest {
                             .put("blocked", true),
                         100L, 1000L, TimestampType.CREATE_TIME);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord.get(OutputFieldType.OFFSET.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.KEY.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.TIMESTAMP.name)).isNull();
@@ -172,7 +172,7 @@ class SinkRecordConverterTest {
             .map(Field::name)
             .containsExactly("user_name", "user_ip", "blocked");
 
-        final var valueRecord = (GenericRecord) avroRecord.get("value");
+        final GenericRecord valueRecord = (GenericRecord) avroRecord.get("value");
         assertThat(valueRecord.get("user_name")).isEqualTo("John Doe");
         assertThat(valueRecord.get("user_ip")).isEqualTo("127.0.0.1");
         assertThat(valueRecord.get("blocked")).isEqualTo(true);
@@ -180,19 +180,19 @@ class SinkRecordConverterTest {
 
     @Test
     void testConvertRecordValueStructWithoutEnvelope() {
-        final var fields =
-                List.of(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
+        final List<OutputField> fields =
+                Arrays.asList(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData, false);
-        final var converter = new SinkRecordConverter(fields, avroData, false);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData, false);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData, false);
 
-        final var recordSchema = SchemaBuilder.struct()
+        final Schema recordSchema = SchemaBuilder.struct()
                 .field("user_name", Schema.STRING_SCHEMA)
                 .field("user_ip", Schema.STRING_SCHEMA)
                 .field("blocked", Schema.BOOLEAN_SCHEMA)
                 .build();
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
@@ -202,7 +202,7 @@ class SinkRecordConverterTest {
                         .put("blocked", true),
                         100L, 1000L, TimestampType.CREATE_TIME);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord.get(OutputFieldType.OFFSET.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.KEY.name)).isNull();
         assertThat(avroRecord.get(OutputFieldType.TIMESTAMP.name)).isNull();
@@ -219,61 +219,69 @@ class SinkRecordConverterTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testConvertRecordValueArray(final boolean envelopeEnabled) {
-        final var fields =
-                List.of(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
+        final List<OutputField> fields =
+                Arrays.asList(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData, envelopeEnabled);
-        final var converter = new SinkRecordConverter(fields, avroData, envelopeEnabled);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData, envelopeEnabled);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData, envelopeEnabled);
 
-        final var recordSchema = SchemaBuilder.array(Schema.INT32_SCHEMA).build();
+        final Schema recordSchema = SchemaBuilder.array(Schema.INT32_SCHEMA).build();
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
-                        recordSchema, List.of(1, 2, 3, 4, 5, 6),
+                        recordSchema, Arrays.asList(1, 2, 3, 4, 5, 6),
                         100L, 1000L, TimestampType.CREATE_TIME);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord).hasToString("{\"value\": [1, 2, 3, 4, 5, 6]}");
     }
 
     @Test
     void testConvertRecordValueMap() {
-        final var fields =
-                List.of(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
+        final List<OutputField> fields =
+                Arrays.asList(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
-        final var converter = new SinkRecordConverter(fields, avroData);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData);
 
-        final var recordSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA).build();
+        final Schema recordSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA).build();
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
-                        recordSchema, Map.of("a", true, "b", false, "c", true),
+                        recordSchema, new HashMap<String, Boolean>() {{
+                                put("a", true);
+                                put("b", false);
+                                put("c", true);
+                            }},
                         100L, 1000L, TimestampType.CREATE_TIME);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord).hasToString("{\"value\": {\"a\": true, \"b\": false, \"c\": true}}");
     }
 
     @Test
     void testConvertRecordValueMapWithoutEnvelope() {
-        final var fields =
-            List.of(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
+        final List<OutputField> fields =
+            Arrays.asList(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE));
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData, false);
-        final var converter = new SinkRecordConverter(fields, avroData, false);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData, false);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData, false);
 
-        final var recordSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA).build();
+        final Schema recordSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA).build();
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
             new SinkRecord(
                 "some-topic", 1,
                 Schema.STRING_SCHEMA, "some-key",
-                recordSchema, new HashMap<>(Map.of("a", true, "b", false, "c", true)),
+                recordSchema, new HashMap<String, Boolean>() {{
+                        put("a", true);
+                        put("b", false);
+                        put("c", true);
+                    }},
                 100L, 1000L, TimestampType.CREATE_TIME);
 
         final org.apache.avro.Schema schema = schemaBuilder.buildSchema(sinkRecord);
@@ -283,7 +291,7 @@ class SinkRecordConverterTest {
 
     @Test
     void testConvertRecordWithAllFields() {
-        final var fields = List.of(
+        final List<OutputField> fields = Arrays.asList(
                 new OutputField(OutputFieldType.KEY, OutputFieldEncodingType.NONE),
                 new OutputField(OutputFieldType.OFFSET, OutputFieldEncodingType.NONE),
                 new OutputField(OutputFieldType.TIMESTAMP, OutputFieldEncodingType.NONE),
@@ -291,20 +299,20 @@ class SinkRecordConverterTest {
                 new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE)
         );
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
-        final var converter = new SinkRecordConverter(fields, avroData);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData);
 
         final Headers headers = new ConnectHeaders();
         headers.add("a", "b", Schema.STRING_SCHEMA);
         headers.add("c", "d", Schema.STRING_SCHEMA);
 
-        final var recordSchema = SchemaBuilder.struct()
+        final Schema recordSchema = SchemaBuilder.struct()
                 .field("user_name", Schema.STRING_SCHEMA)
                 .field("user_ip", Schema.STRING_SCHEMA)
                 .field("blocked", Schema.BOOLEAN_SCHEMA)
                 .build();
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
@@ -315,7 +323,7 @@ class SinkRecordConverterTest {
                                 .put("blocked", true),
                         100L, 1000L, TimestampType.CREATE_TIME, headers);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord.get(OutputFieldType.KEY.name)).isNotNull();
         assertThat(avroRecord.get(OutputFieldType.OFFSET.name)).isNotNull();
         assertThat(avroRecord.get(OutputFieldType.TIMESTAMP.name)).isNotNull();
@@ -339,7 +347,7 @@ class SinkRecordConverterTest {
 
     @Test
     void testConvertRecordWithAllFieldsWithoutHeaders() {
-        final var fields = List.of(
+        final List<OutputField> fields = Arrays.asList(
                 new OutputField(OutputFieldType.KEY, OutputFieldEncodingType.NONE),
                 new OutputField(OutputFieldType.OFFSET, OutputFieldEncodingType.NONE),
                 new OutputField(OutputFieldType.TIMESTAMP, OutputFieldEncodingType.NONE),
@@ -347,16 +355,16 @@ class SinkRecordConverterTest {
                 new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE)
         );
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
-        final var converter = new SinkRecordConverter(fields, avroData);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData);
 
-        final var recordSchema = SchemaBuilder.struct()
+        final Schema recordSchema = SchemaBuilder.struct()
                 .field("user_name", Schema.STRING_SCHEMA)
                 .field("user_ip", Schema.STRING_SCHEMA)
                 .field("blocked", Schema.BOOLEAN_SCHEMA)
                 .build();
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
@@ -367,7 +375,7 @@ class SinkRecordConverterTest {
                                 .put("blocked", true),
                         100L, 1000L, TimestampType.CREATE_TIME);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord.get(OutputFieldType.KEY.name)).isNotNull();
         assertThat(avroRecord.get(OutputFieldType.OFFSET.name)).isNotNull();
         assertThat(avroRecord.get(OutputFieldType.TIMESTAMP.name)).isNotNull();
@@ -388,23 +396,23 @@ class SinkRecordConverterTest {
 
     @Test
     void testConvertRecordWithPartialFields() {
-        final var fields = List.of(
+        final List<OutputField> fields = Arrays.asList(
                 new OutputField(OutputFieldType.KEY, OutputFieldEncodingType.NONE),
                 new OutputField(OutputFieldType.OFFSET, OutputFieldEncodingType.NONE),
                 new OutputField(OutputFieldType.TIMESTAMP, OutputFieldEncodingType.NONE)
         );
 
-        final var schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
-        final var converter = new SinkRecordConverter(fields, avroData);
+        final ParquetSchemaBuilder schemaBuilder = new ParquetSchemaBuilder(fields, avroData);
+        final SinkRecordConverter converter = new SinkRecordConverter(fields, avroData);
 
-        final var sinkRecord =
+        final SinkRecord sinkRecord =
                 new SinkRecord(
                         "some-topic", 1,
                         Schema.STRING_SCHEMA, "some-key",
                         Schema.STRING_SCHEMA, "some-value",
                         100L, 1000L, TimestampType.CREATE_TIME);
 
-        final var avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
+        final GenericRecord avroRecord = converter.convert(sinkRecord, schemaBuilder.buildSchema(sinkRecord));
         assertThat(avroRecord.get(OutputFieldType.KEY.name)).isNotNull();
         assertThat(avroRecord.get(OutputFieldType.OFFSET.name)).isNotNull();
         assertThat(avroRecord.get(OutputFieldType.TIMESTAMP.name)).isNotNull();


### PR DESCRIPTION
In our current strimzi based setup, we are still using java 8, hence we
need this connector to be binary compatible with that VM.

Relaxed compilation parameters from warnings to errors, as many of them
we can ignore them by the moment.

Also disabled javadoc for the moment.

As a summary of changes (from big to little):

* loads of var replacements to current types
* loads of List.of replaced with Arrays.asList
* loads of Map.of replaced with "new HashMap<>() {{ }}" pattern
* backported String.isBlank() with a regex